### PR TITLE
Fix: Payment ordering and decimal places

### DIFF
--- a/src/components/general/payments/MoneyDiff/MoneyDiff.component.tsx
+++ b/src/components/general/payments/MoneyDiff/MoneyDiff.component.tsx
@@ -20,7 +20,12 @@ export const MoneyDiff: React.FC<MoneyDiffProps> = ({ name, amount, last, onPres
       <ListItem last={last} onPress={onPress} separatorStyle={separatorStyle}>
         <Text style={styles.moneyDiffName}>{name}</Text>
         <Text style={[styles.moneyDiffAmount, amount < 0 ? styles.negativeDiff : styles.positiveDiff]}>
-          {amount.toFixed(2)} €
+          {Intl.NumberFormat('de-de', {
+            currency: 'EUR',
+            maximumFractionDigits: 2,
+            minimumFractionDigits: 2,
+          }).format(amount)}
+          €
         </Text>
       </ListItem>
     </>

--- a/src/screens/History/History.screen.tsx
+++ b/src/screens/History/History.screen.tsx
@@ -23,7 +23,7 @@ export const HistoryView: React.FC<HistoryViewProps> = () => {
 
   // update payment state
   const updatePayments = useCallback((ps: Pesca.PaymentInformation[]) => {
-    setLocalPayments(ps.sort((a, b) => a.date - b.date));
+    setLocalPayments(ps.sort((a, b) => b.date - a.date));
   }, []);
 
   // on update of storage payments, update state payments

--- a/src/screens/auth/Login/Login.style.ts
+++ b/src/screens/auth/Login/Login.style.ts
@@ -1,6 +1,6 @@
+import variables from '@moneyboy/config/variables';
 import { useStyle } from '@moneyboy/hooks/useStyle';
 import { StyleSheet } from 'react-native';
-import variables from '@moneyboy/config/variables';
 
 export const useLoginStyles = () => {
   const { Texts, Buttons, Colors } = useStyle();


### PR DESCRIPTION
Order payments in history view chronologically and display decimal places correctly.